### PR TITLE
readme cleanup: put project usage instructions inside

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,20 @@
-# Coding puzzle
+# CLI role playing game
 
-We want you to program a command line based role playing game.
+## Requirements
+* git
+* jdk 1.8
+* gradle 4.5
 
-Here are the stories:
-* As a player I want to create a character
-* As a player I want to explore
-* As a player I want to gain experience through fighting
-* As a player I want to save and resume a game
+## Build
+To build the project please execute the following command
+```
+$ git clone "https://github.com/aplotnikov/role-playing-game.git"
+$ cd role-playing-game
+$ gradle build
+```
 
-These will be the technical constraints:
-* Use Java
-* Libraries and Frameworks are only allowed for testing and build pipelines
-* Use best in industry agile engineering practices
-* Please build for the command line
-
-And here’s a little guidance:
-
-* We wouldn’t ask you to fulfil this challenge if we haven’t had done it ourselves. 
-The people looking at your code understand the problems we have been asking you to solve and most of us have been investing 3-­6 hours of effort. 
-We generally would like you to use this as a guideline for your effort. 
-But if you’re having fun and want to switch to beast mode, we can’t hold you, can we?
-
-* If you need a topic: Choose something like Fantasy, Science Fiction, Cyberpunk, Fan fiction for a TV series or any random things. Surprise us!
-
-* We’re not too bothered with the looks. Nevertheless, doesn’t everyone like some colors or ascii pictures when working on CLI?
-
-* We are keen to see how much you think is enough, and how much would go into a Minimum Viable Product. 
-As a guide, elegant and simple wins over feature rich every time, though extra gold stars are given to people who get excited and do more because they are having fun.
-
-* Do you test drive your code? Are you aware of coverage?
-
-* Does the code have instructions on how to run, build and extend it?
-
-* We also consider the extensibility of the code produced. 
-Well factored code should be relatively easily extended. As examples: Gaining experience has no effect in the current stories, 
-but we bet it will have in the future. Will exploration be tracked on a map? 
-Or maybe someone wants to switch the topic from Harry Potter to Lord of the Rings.
-
-* This job is primarily Java, so submissions should be in that.
-
-* Any indicator of design (DDD, or design patterns) would make us smile.
-
-* Since the topic is pretty vast you are totally allowed to put your code to github to brag around with it.
+## Run
+After the project is built please run the following command to launch the game
+```
+$ java -jar ./build/libs/role-playing-game-0.0.1-SNAPSHOT.jar
+```


### PR DESCRIPTION
This PR is to hide actual puzzle rules published in the readme of the project to make impossible to find the puzzle solution via google